### PR TITLE
importing UIKit

### DIFF
--- a/DZImageEditing/Helpers/DZImageHelper.h
+++ b/DZImageEditing/Helpers/DZImageHelper.h
@@ -4,7 +4,7 @@
 //
 
 #import <Foundation/Foundation.h>
-
+#import <UIKit/UIKit.h>
 
 @interface DZImageHelper : NSObject
 

--- a/DZImageEditing/Protocols/DZImageEditingControllerDelegate.h
+++ b/DZImageEditing/Protocols/DZImageEditingControllerDelegate.h
@@ -4,6 +4,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @class DZImageEditingController;
 


### PR DESCRIPTION
if using DZImageEditing as an git submodule or if someone directly imports files
Since there is no UIKit available, UIImage, UIView, CGFloat are creating build error
